### PR TITLE
docs(readme): tighten subtitle for V1 (one-sentence positioning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # keystrum
 
-### Strum your keyboard. Practice guitar chords — no guitar needed.
+### Strum guitar chords on your QWERTY keyboard — no guitar needed.
 
 A browser-based virtual guitar that maps your QWERTY keyboard to a 6-chord strum machine.<br/>
 Four rows become four strings. Six columns become six chords. Real strum detection.<br/>


### PR DESCRIPTION
## Summary

Tightens the README subtitle from two short sentences into one.

| | Before | After |
|---|--------|-------|
| Text | `### Strum your keyboard. Practice guitar chords — no guitar needed.` | `### Strum guitar chords on your QWERTY keyboard — no guitar needed.` |
| Sentences | 2 | 1 |
| Length | 64 chars | 65 chars |
| Category named | implicit | explicit ("guitar chords") |
| Differentiator named | "no guitar needed" | "QWERTY keyboard" + "no guitar needed" |

## Test plan

- [ ] Visual: README still renders well on github.com (centered hero block)
- [ ] Branding: subtitle still reads naturally to a first-time visitor
- [ ] CI: no test impact (text-only change in README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)