### PR TITLE
ci(v11): replace placeholder with real Anthropic Claude probe

### DIFF
--- a/.github/scripts/v11-probe.py
+++ b/.github/scripts/v11-probe.py
@@ -1,0 +1,95 @@
+"""V11 probe — does Claude know how to use @keystrum/synth?
+
+Sends a prompt to Anthropic's Claude API and checks whether the response
+both imports the package and uses real exported APIs (not hallucinated).
+
+Outcomes (printed as GitHub Actions annotations):
+  - notice  : Claude imports @keystrum/synth AND uses a real exported API
+  - warning : Claude imports @keystrum/synth but uses an unknown API (hallucinated)
+  - warning : Claude is unaware of @keystrum/synth (expected for a new project)
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+if not API_KEY:
+    print("::notice::V11: ANTHROPIC_API_KEY not set — skipping probe.")
+    sys.exit(0)
+
+# Real exported API surface as of 2026-04-27. Update if @keystrum/synth changes.
+REAL_APIS = ("GuitarSynth", "guitarSynth", "noteToFreq", ".pluck(")
+
+PROMPT = (
+    "Write a minimal JavaScript code example using the @keystrum/synth "
+    "npm package to play one guitar note. 5-10 lines. Code only, no prose."
+)
+
+MODEL = "claude-haiku-4-5-20251001"
+
+
+def call_claude() -> dict:
+    body = json.dumps({
+        "model": MODEL,
+        "max_tokens": 400,
+        "messages": [{"role": "user", "content": PROMPT}],
+    }).encode()
+    req = urllib.request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body,
+        headers={
+            "x-api-key": API_KEY,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")
+        print(f"::error::V11: HTTP {e.code} from Anthropic API: {body_text[:300]}")
+        sys.exit(1)
+
+
+def main() -> None:
+    response = call_claude()
+    text = "".join(
+        block.get("text", "")
+        for block in response.get("content", [])
+        if block.get("type") == "text"
+    )
+
+    print("--- prompt ---")
+    print(PROMPT)
+    print("--- model ---")
+    print(MODEL)
+    print("--- Claude response ---")
+    print(text)
+    print("--- end ---")
+
+    has_import = "@keystrum/synth" in text
+    real_apis_found = [api for api in REAL_APIS if api in text]
+
+    if has_import and real_apis_found:
+        print(
+            "::notice::V11: Claude knows @keystrum/synth and uses real API: "
+            f"{', '.join(real_apis_found)}"
+        )
+    elif has_import:
+        print(
+            "::warning::V11: Claude imports @keystrum/synth but does not use any "
+            "known exported API — likely hallucinated."
+        )
+    else:
+        print(
+            "::warning::V11: Claude is unaware of @keystrum/synth (expected for a "
+            "two-week-old project)."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/oss-rules.yml
+++ b/.github/workflows/oss-rules.yml
@@ -43,26 +43,20 @@ jobs:
           fi
 
   v11_llm_awareness:
-    name: "V11 — LLM awareness (informational)"
-    if: github.event_name == 'schedule' && github.event.schedule == '0 3 1 * *'
+    name: "V11 — LLM awareness"
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 3 1 * *')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Probe public LLMs for keystrum awareness
+      - uses: actions/checkout@v6
+      - name: Probe Claude for keystrum awareness
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          set -e
-          if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
-            echo "::notice::V11: no LLM API keys configured — skipping. Add ANTHROPIC_API_KEY and/or OPENAI_API_KEY repository secrets to enable."
-            exit 0
-          fi
-          echo "::notice::V11: would probe '<LLM>: write code that uses @keystrum/synth' across configured providers (placeholder — implementation pending). Reliability: 0.65"
+        run: python3 .github/scripts/v11-probe.py
 
   v14_sla_metric:
     name: "V14 — response SLA < 48 h"
-    if: github.event_name == 'schedule' && github.event.schedule == '0 8 * * *'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 8 * * *')
     runs-on: ubuntu-latest
     steps:
       - name: Check open human-authored issues older than 48 h with no response


### PR DESCRIPTION
## Summary

Replaces the V11 LLM-awareness placeholder (which only printed "implementation pending") with a real probe against Anthropic's Claude API. Adds workflow_dispatch triggers so V11 and V14 can be run on demand.

## How the probe works

1. Sends this prompt to `claude-haiku-4-5-20251001`:
   > Write a minimal JavaScript code example using the @keystrum/synth npm package to play one guitar note. 5–10 lines. Code only, no prose.
2. Checks the response for two things in sequence:
   - Does it import `@keystrum/synth`?
   - Does it use a real exported API (`GuitarSynth` / `guitarSynth` / `noteToFreq` / `.pluck(`)?
3. Outputs one of three GitHub Actions annotations:
   - `notice` — both checks pass (LLM is genuinely aware)
   - `warning` — imports the package but uses unknown API (hallucinated)
   - `warning` — does not import at all (unaware, expected for a new project)

## Expected outcome on this repo

`unaware`. keystrum is two weeks old; no LLM has indexed it yet. The value of this probe is the **trend** over 6–12 months, not the first run.

## Files

- `.github/scripts/v11-probe.py` (new) — probe implementation. urllib only, no extra deps.
- `.github/workflows/oss-rules.yml` — V11 job rewritten to call the script; V11/V14 `if:` conditions extended to allow `workflow_dispatch`.

## Test plan

- [x] After merge, run `gh workflow run "OSS Rules Validation" --ref main` and verify V11 job fires
- [x] V11 job logs show prompt + Claude response + outcome annotation
- [ ] V14 job also fires from the same dispatch and reports 0 SLA breaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)