### PR TITLE
docs(readme): tighten subtitle to single sentence with explicit categ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # keystrum
 
-### Strum your keyboard. Practice guitar chords — no guitar needed.
+### Strum guitar chords on your QWERTY keyboard — no guitar needed.
 
 A browser-based virtual guitar that maps your QWERTY keyboard to a 6-chord strum machine.<br/>
 Four rows become four strings. Six columns become six chords. Real strum detection.<br/>


### PR DESCRIPTION
…ory (V1)

Before: "Strum your keyboard. Practice guitar chords — no guitar needed."
After:  "Strum guitar chords on your QWERTY keyboard — no guitar needed."

Single statement (65 chars), names the category ("guitar chords") and the differentiator ("QWERTY keyboard, no guitar needed") in one line. Passes the 30-second comprehension test better than two short sentences that asked the reader to connect them mentally.

## What does this PR do?

<!-- A brief description of the change -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] New song

## Checklist

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] Tested in browser (if UI change)
